### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Josh Jacob/TNEFsEnough.pkg.recipe
+++ b/Josh Jacob/TNEFsEnough.pkg.recipe
@@ -75,9 +75,9 @@
 						<string>purge_ds_store</string>
 						<key>pkgdir</key>
 						<string>%RECIPE_CACHE_DIR%</string>
+						<key>pkgname</key>
+						<string>TNEFs Enough-%version%</string>
 					</dict>
-					<key>pkgname</key>
-					<string>TNEFs Enough-%version%</string>
 				</dict>
 				<key>Processor</key>
 				<string>PkgCreator</string>

--- a/Solibri IFC Optimizer/Solibri IFC Optimizer.pkg.recipe
+++ b/Solibri IFC Optimizer/Solibri IFC Optimizer.pkg.recipe
@@ -111,9 +111,9 @@ install_dir=$(dirname "$0")
 						<string>flat</string>
 						<key>scripts</key>
 						<string>Scripts</string>
+						<key>pkgname</key>
+						<string>%NAME%-%version%</string>
 					</dict>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
 				</dict>
 				<key>Processor</key>
 				<string>PkgCreator</string>

--- a/Touche/Touche.pkg.recipe
+++ b/Touche/Touche.pkg.recipe
@@ -68,9 +68,9 @@
 						<string>purge_ds_store</string>
 						<key>pkgdir</key>
 						<string>%RECIPE_CACHE_DIR%</string>
+						<key>pkgname</key>
+						<string>Touche-%version%</string>
 					</dict>
-					<key>pkgname</key>
-					<string>Touche-%version%</string>
 				</dict>
 				<key>Processor</key>
 				<string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).