### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Amethyst/Amethyst.pkg.recipe
+++ b/Amethyst/Amethyst.pkg.recipe
@@ -8,8 +8,6 @@
 		<string>com.github.ahousseini-recipes.pkg.Amethyst</string>
 		<key>Input</key>
 		<dict>
-			<key>BUNDLE_ID</key>
-			<string>com.amethyst.Amethyst</string>
 			<key>NAME</key>
 			<string>Amethyst</string>
 		</dict>

--- a/Anydesk/Anydesk.pkg.recipe
+++ b/Anydesk/Anydesk.pkg.recipe
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
@@ -8,8 +8,6 @@
 		<string>com.github.ahousseini-recipes.pkg.Anydesk</string>
 		<key>Input</key>
 		<dict>
-			<key>BUNDLE_ID</key>
-			<string>com.philandro.anydesk</string>
 			<key>NAME</key>
 			<string>Anydesk</string>
 		</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Amethyst/Amethyst.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/ahousseini-recipes/Amethyst/Amethyst.pkg.recipe
Processing repos/ahousseini-recipes/Amethyst/Amethyst.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://ianyh.com/amethyst/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 91
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 0.15.4
SparkleUpdateInfoProvider: Found URL https://github.com/ianyh/Amethyst/releases/download/v0.15.4/Amethyst.zip
{'Output': {'url': 'https://github.com/ianyh/Amethyst/releases/download/v0.15.4/Amethyst.zip',
            'version': '0.15.4'}}
URLDownloader
{'Input': {'url': 'https://github.com/ianyh/Amethyst/releases/download/v0.15.4/Amethyst.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/downloads/Amethyst.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/downloads/Amethyst.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': 'true'}}
Unarchiver: Guessed archive format 'zip' from filename Amethyst.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/downloads/Amethyst.zip to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.amethyst.Amethyst" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "82P2XLB4UH")',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/*.app'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app' from globbed '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/*.app'
{'Output': {'found_filename': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app'}}
FileMover
{'Input': {'source': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app',
           'target': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app'}}
FileMover: File ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app moved to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst at ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst.dmg
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst/Amethyst.app',
           'version': '0.15.4'}}
AppPkgCreator: BundleID: com.amethyst.Amethyst
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/Amethyst-0.15.4.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '0.15.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Amethyst/receipts/Amethyst.pkg-receipt-20210213-235205.plist

Nothing downloaded, packaged or imported.
```

## ✅ Anydesk/Anydesk.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/ahousseini-recipes/Anydesk/Anydesk.pkg.recipe
Processing repos/ahousseini-recipes/Anydesk/Anydesk.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Anydesk.dmg',
           'url': 'https://download.anydesk.com/anydesk.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Anydesk/downloads/Anydesk.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Anydesk/downloads/Anydesk.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Anydesk/downloads/Anydesk.dmg
AppPkgCreator: Using path '/private/tmp/dmg.sjeKcd/AnyDesk.app' matched from globbed '/private/tmp/dmg.sjeKcd/*.app'.
AppPkgCreator: Version: 6.1.1
AppPkgCreator: BundleID: com.philandro.anydesk
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Anydesk/AnyDesk-6.1.1.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '6.1.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Anydesk/receipts/Anydesk.pkg-receipt-20210213-235209.plist

Nothing downloaded, packaged or imported.
```

