### PR TITLE
Aircall: updated download URL

### DIFF
--- a/Aircall/Aircall.download.recipe
+++ b/Aircall/Aircall.download.recipe
@@ -19,7 +19,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>re_pattern</key>
-					<string>https://s3-us-west-1.amazonaws.com/aircall-electron-releases/production/Aircall-[0-9\.]*.zip</string>
+					<string>https://download-electron.aircall.io/Aircall-[0-9\.]*.zip</string>
 					<key>result_output_var_name</key>
 					<string>url</string>
 					<key>url</key>


### PR DESCRIPTION
Received the following error this morning:

`No match found on URL: https://electron.aircall.io/update/osx/0.0.0`

Looks like Aircall changed their download URL from AWS to something else. Updated in the download recipe and all is working as expected. Let me know if you have any questions or input.

Thanks for all your work!