### PR TITLE
Update MonitorControl.download.recipe

### DIFF
--- a/MonitorControl/MonitorControl.download.recipe
+++ b/MonitorControl/MonitorControl.download.recipe
@@ -56,7 +56,7 @@
 				<key>input_plist_path</key>
 				<string>%pathname%/MonitorControl.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>


### PR DESCRIPTION
Use CFBundleShortVersionString in Versioner, as it now contains the correct version number