### PR TITLE
Update DBeaver.pkg.recipe

### DIFF
--- a/DBeaver/DBeaver.pkg.recipe
+++ b/DBeaver/DBeaver.pkg.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%ARCH%-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%os%-%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
changed the variable from "ARCH" to "os", as thats the variable the download recipe uses.