### PR TITLE
Update GoogleEarthPro.pkg.recipe

### DIFF
--- a/GoogleEarthPro/GoogleEarthPro.pkg.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.pkg.recipe
@@ -72,7 +72,7 @@
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
-				<string>%pathname%</string>
+				<string>%pathname%/*.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>


### PR DESCRIPTION
The current recipe is broken and just copies the .dmg as a .pkg which then won't open.  Tweaked the PkgCopier processor to find the pkg inside the dmg and copy that.