### PR TITLE
Update PrusaSlicer.download.recipe path in dmg

### DIFF
--- a/PrusaSlicer/PrusaSlicer.download.recipe
+++ b/PrusaSlicer/PrusaSlicer.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/PrusaSlicer.app</string>
+				<string>%pathname%/Original Prusa Drivers/PrusaSlicer.app</string>
 				<key>requirement</key>
 				<string>identifier "com.prusa3d.slic3r/" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = DKPB65N43Z</string>
 			</dict>


### PR DESCRIPTION
CodeSignatureVerifier failed to find the app after it is moved into a folder ("Original Prusa Drivers"). Updated download recipe with new path for verification.