### PR TITLE
Add app_path key for AppPkgCreator

### DIFF
--- a/PrusaSlicer/PrusaSlicer.pkg.recipe
+++ b/PrusaSlicer/PrusaSlicer.pkg.recipe
@@ -22,6 +22,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>app_path</key>
+				<string>%pathname%/Original Prusa Drivers/PrusaSlicer.app</string>
 				<key>bundleid</key>
 				<string>com.prusa3d.slic3r</string>
 				<key>version</key>


### PR DESCRIPTION
App is in a nested folder in the DMG, so AppPkgCreator was unable to locate the .app.