### PR TITLE
Project uses tag with a version_ prefix

### DIFF
--- a/PrusaSlicer/PrusaSlicer.download.recipe
+++ b/PrusaSlicer/PrusaSlicer.download.recipe
@@ -36,6 +36,19 @@
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
+		</dict>	
+		<dict>
+			<key>Arguments</key>
+			<dict>
+			  <key>url</key>
+			  <string>%asset_url%</string>
+				<key>re_pattern</key>
+				<string><![CDATA[(?<=\/PrusaSlicer-)[\d\.]+]]></string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
GithubReleasesInfoProvider not providing proper version, as the project does not use a major.minor.build version in the tag, but version_major.minor.build

(was returning ersion_2.8.1 as the version)