### PR TITLE
Deprecate FontExplorerX recipes

### DIFF
--- a/FontExplorer X Pro/FontExplorer X Pro.download.recipe
+++ b/FontExplorer X Pro/FontExplorer X Pro.download.recipe
@@ -14,9 +14,18 @@
 		<string>FontExplorer X Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>FontExplorerX is no longer available for download (details: https://www.fontexplorerx.com/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the FontExplorerX recipes, since the software is no longer available for download.
