### PR TITLE
Deprecate TechSmith Capture recipes

### DIFF
--- a/TechSmith Capture/TechSmith Capture.download.recipe
+++ b/TechSmith Capture/TechSmith Capture.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the TechSmithCapture recipes in the blackthroat-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
The TechsmithCapture recipes in this recipe are insufficiently distinct from similar recipes in the AutoPkg org to warrant the additional maintenance effort. This PR deprecates the TechSmith Capture recipes in this repo and points users to alternatives in the blackthroat-recipes repo.
