### PR TITLE
Deprecate Freeplane recipes

### DIFF
--- a/Freeplane/Freeplane.download.recipe
+++ b/Freeplane/Freeplane.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Freeplane recipes in the fishd72-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>curl_opts</key>


### PR DESCRIPTION
The Freeplane recipes in this repo are redundant with the ones in fishd72-recipes, and appear to provide no added benefit. This PR deprecates these Freeplane recipes and points users to the others.
