### PR TITLE
Remove version-specific download URL for iStopMotion

### DIFF
--- a/iStopMotion/iStopMotion.download.recipe
+++ b/iStopMotion/iStopMotion.download.recipe
@@ -30,9 +30,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.zip</string>
-				<key>url</key>
-				<string>https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_3.8.2-16057.app.zip</string>
+				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The current iStopMotion recipes have a hard-coded download URL, which is contrary to the purpose of AutoPkg. This PR allows SparkleUpdateInfoProvider to provide a dynamic download URL for each new version of iStopMotion.

Verbose recipe run output:

```
% autopkg run -vvq 'iStopMotion/iStopMotion.download.recipe'
Processing iStopMotion/iStopMotion.download.recipe...
WARNING: iStopMotion/iStopMotion.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://sparkle.boinx.com/appcast.lasso?appName=iStopMotion'}}
SparkleUpdateInfoProvider: Items in feed: 38
SparkleUpdateInfoProvider: Items in default channel: 38
SparkleUpdateInfoProvider: Version retrieved from appcast: 3.8-16051.app
SparkleUpdateInfoProvider: Found URL https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_3.8-16051.app.zip
{'Output': {'url': 'https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_3.8-16051.app.zip',
            'version': '3.8-16051.app'}}
URLDownloader
{'Input': {'filename': 'iStopMotion-3.8-16051.app.zip',
           'url': 'https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_3.8-16051.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 14 May 2016 14:45:01 GMT
URLDownloader: Storing new ETag header: "2ab237a-532ce6fa2b3a0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/downloads/iStopMotion-3.8-16051.app.zip
{'Output': {'download_changed': True,
            'etag': '"2ab237a-532ce6fa2b3a0"',
            'last_modified': 'Sat, 14 May 2016 14:45:01 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/downloads/iStopMotion-3.8-16051.app.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/downloads/iStopMotion-3.8-16051.app.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/downloads/iStopMotion-3.8-16051.app.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename iStopMotion-3.8-16051.app.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/downloads/iStopMotion-3.8-16051.app.zip to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion/iStopMotion.app',
           'requirement': 'identifier "com.boinx.iStopMotion3" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"6372P8EH2J"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion/iStopMotion.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion/iStopMotion.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion/iStopMotion.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion/iStopMotion.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 3.8 in file ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/iStopMotion/iStopMotion.app/Contents/Info.plist
{'Output': {'version': '3.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/receipts/iStopMotion.download-receipt-20241228-123031.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.iStopMotion/downloads/iStopMotion-3.8-16051.app.zip
```
