### PR TITLE
Add code signature verification to ONLYOFFICE recipes

### DIFF
--- a/ONLYOFFICE/ONLYOFFICE.download.recipe
+++ b/ONLYOFFICE/ONLYOFFICE.download.recipe
@@ -52,6 +52,17 @@
 			<key>Processor</key>
 			<string>Unarchiver</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/ONLYOFFICE.app</string>
+				<key>requirements</key>
+				<string>anchor apple generic and identifier "asc.onlyoffice.ONLYOFFICE" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2WH24U26GJ")</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds code signature verification to the ONLYOFFICE recipes.

Verbose recipe run output:

```
% autopkg run -vvq 'ONLYOFFICE/ONLYOFFICE.download.recipe'
Processing ONLYOFFICE/ONLYOFFICE.download.recipe...
WARNING: ONLYOFFICE/ONLYOFFICE.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://download.onlyoffice.com/install/desktop/editors/mac/x86_64/onlyoffice.xml'}}
SparkleUpdateInfoProvider: Items in feed: 4
SparkleUpdateInfoProvider: Items in default channel: 4
SparkleUpdateInfoProvider: Version retrieved from appcast: 550
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 8.2.2
SparkleUpdateInfoProvider: Found URL https://download.onlyoffice.com/install/desktop/editors/mac/x86_64/updates/ONLYOFFICE-x86_64-8.2.2.zip
{'Output': {'url': 'https://download.onlyoffice.com/install/desktop/editors/mac/x86_64/updates/ONLYOFFICE-x86_64-8.2.2.zip',
            'version': '8.2.2'}}
URLDownloader
{'Input': {'filename': 'ONLYOFFICE-8.2.2.zip',
           'url': 'https://download.onlyoffice.com/install/desktop/editors/mac/x86_64/updates/ONLYOFFICE-x86_64-8.2.2.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/downloads/ONLYOFFICE-8.2.2.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/downloads/ONLYOFFICE-8.2.2.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/downloads/ONLYOFFICE-8.2.2.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/ONLYOFFICE',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename ONLYOFFICE-8.2.2.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/downloads/ONLYOFFICE-8.2.2.zip to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/ONLYOFFICE
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/ONLYOFFICE/ONLYOFFICE.app'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: WARNING: This recipe is using 'requirements' when it should be using 'requirement'. This will become an error in future versions of AutoPkg.
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/ONLYOFFICE/ONLYOFFICE.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/ONLYOFFICE/ONLYOFFICE.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/ONLYOFFICE/ONLYOFFICE.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.ONLYOFFICE/receipts/ONLYOFFICE.download-receipt-20241229-124603.plist

Nothing downloaded, packaged or imported.
```
