### PR TITLE
Change parent recipe of balenaEtcher.pkg

### DIFF
--- a/balenaEtcher/balenaEtcher.download.recipe
+++ b/balenaEtcher/balenaEtcher.download.recipe
@@ -14,9 +14,18 @@
 		<string>balenaEtcher</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the balenaEtcher recipes in the dataJAR-recipes or ahousseini-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/balenaEtcher/balenaEtcher.pkg.recipe
+++ b/balenaEtcher/balenaEtcher.pkg.recipe
@@ -16,7 +16,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.ahousseini-recipes.download.balenaEtcher</string>
+	<string>com.github.dataJAR-recipes.download.balenaEtcher</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR switches the parent recipe of balenaEtcher.pkg to dataJAR's download recipe, and deprecates the download recipe in this repo.

Verboose recipe run output:

```
% autopkg run -vvq balenaEtcher.pkg.recipe
Processing balenaEtcher.pkg.recipe...
WARNING: balenaEtcher.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'balenaEtcher-.*arm64\\.dmg',
           'github_repo': 'balena-io/etcher',
           'include_prereleases': '',
           'latest_only': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'balenaEtcher-.*arm64\.dmg' among asset(s): balena-etcher-1.19.25-1.x86_64.rpm, balena-etcher_1.19.25_amd64.deb, balenaEtcher-1.19.25-arm64.dmg, balenaEtcher-1.19.25-x64.AppImage, balenaEtcher-1.19.25-x64.dmg, balenaEtcher-1.19.25.Setup.exe, balenaEtcher-darwin-arm64-1.19.25.zip, balenaEtcher-darwin-x64-1.19.25.zip, balenaEtcher-linux-x64-1.19.25.zip, balenaEtcher-win32-x64-1.19.25.zip, npm-sbom.xml, SHA256SUMS.Darwin.arm64.txt, SHA256SUMS.Darwin.x64.txt, SHA256SUMS.Linux.x64.txt, SHA256SUMS.Windows.x64.txt
GitHubReleasesInfoProvider: Selected asset 'balenaEtcher-1.19.25-arm64.dmg' from release 'v1.19.25'
{'Output': {'asset_created_at': '2024-10-10T10:01:59Z',
            'asset_url': 'https://api.github.com/repos/balena-io/etcher/releases/assets/198146056',
            'release_notes': 'c726b51d (patch: bump etcher-sdk to 9.1.2, '
                             '2024-10-09)\r\n',
            'url': 'https://github.com/balena-io/etcher/releases/download/v1.19.25/balenaEtcher-1.19.25-arm64.dmg',
            'version': '1.19.25'}}
URLDownloader
{'Input': {'url': 'https://github.com/balena-io/etcher/releases/download/v1.19.25/balenaEtcher-1.19.25-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 10 Oct 2024 10:02:03 GMT
URLDownloader: Storing new ETag header: "0x8DCE912974EA235"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/downloads/balenaEtcher-1.19.25-arm64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DCE912974EA235"',
            'last_modified': 'Thu, 10 Oct 2024 10:02:03 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/downloads/balenaEtcher-1.19.25-arm64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/downloads/balenaEtcher-1.19.25-arm64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/downloads/balenaEtcher-1.19.25-arm64.dmg/balenaEtcher.app',
           'requirement': 'identifier "io.balena.etcher" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"66H43P8FRG"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/downloads/balenaEtcher-1.19.25-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.KF33GC/balenaEtcher.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.KF33GC/balenaEtcher.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.KF33GC/balenaEtcher.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '1.19.25'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/downloads/balenaEtcher-1.19.25-arm64.dmg
AppPkgCreator: Using path '/private/tmp/dmg.QtVwDm/balenaEtcher.app' matched from globbed '/private/tmp/dmg.QtVwDm/*.app'.
AppPkgCreator: BundleID: io.balena.etcher
AppPkgCreator: Copied /private/tmp/dmg.QtVwDm/balenaEtcher.app to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/payload/Applications/balenaEtcher.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'io.balena.etcher',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/balenaEtcher-1.19.25.pkg',
                                                        'version': '1.19.25'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.19.25'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/receipts/balenaEtcher.pkg-receipt-20241230-210112.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/downloads/balenaEtcher-1.19.25-arm64.dmg

The following packages were built:
    Identifier        Version  Pkg Path
    ----------        -------  --------
    io.balena.etcher  1.19.25  ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.balenaEtcher/balenaEtcher-1.19.25.pkg
```
