### PR TITLE
Deprecate Google Earth recipes

### DIFF
--- a/GoogleEarthPro/GoogleEarthPro.download.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.download.recipe
@@ -14,9 +14,18 @@
 		<string>Google Earth Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the GoogleEarthPro recipes in the nstrauss-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/GoogleEarthPro/GoogleEarthPro.download.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.download.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>warning_message</key>
-				<string>Consider switching to the GoogleEarthPro recipes in the nstrauss-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+				<string>Consider switching to the GoogleEarthPro recipes in the autopkg/recipes repo. This recipe is deprecated and will be removed in the future.</string>
 			</dict>
 		</dict>
 		<dict>

--- a/GoogleEarthPro/GoogleEarthPro.download.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.download.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>warning_message</key>
-				<string>Consider switching to the GoogleEarthPro recipes in the autopkg/recipes repo. This recipe is deprecated and will be removed in the future.</string>
+				<string>Consider switching to the GoogleEarth recipes in the autopkg/recipes repo. This recipe is deprecated and will be removed in the future.</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The GoogleEarthPro recipes in this repository are not sufficiently distinct from other recipes in the AutoPkg org to warrant the extra maintenance they will require. This PR deprecates the KnockKnock recipes in this repo and points users to specific alternatives in the autopkg/recipes repo.