### PR TITLE
Change parent recipe of Audacity.pkg

### DIFF
--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -16,9 +16,18 @@
 		<string>Audacity</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Audacity recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Audacity/Audacity.pkg.recipe
+++ b/Audacity/Audacity.pkg.recipe
@@ -14,9 +14,20 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.ahousseini-recipes.download.Audacity</string>
+	<string>com.github.dataJAR-recipes.download.Audacity</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/Audacity.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
This PR changes the parent of Audacity.pkg to the download recipe in dataJAR-recipes, and deprecates the download recipe in this repo. The Versioner process has been moved into the pkg recipe to facilitate this transition.

Verbose recipe run output:

```
% autopkg run -vvq Audacity.pkg.recipe
Processing Audacity.pkg.recipe...
WARNING: Audacity.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'audacity-macOS-(\\d(\\.\\d)+)-x86_64\\.dmg',
           'github_repo': 'audacity/audacity'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'audacity-macOS-(\d(\.\d)+)-x86_64\.dmg' among asset(s): audacity-win-3.7.1-64bit.zip, audacity-win-3.7.1-32bit.zip, audacity-win-3.7.1-32bit.exe, audacity-win-3.7.1-64bit.exe, audacity-sources-3.7.1.tar.gz, audacity-macOS-3.7.1-x86_64.dmg, audacity-macOS-3.7.1-universal.dmg, audacity-macOS-3.7.1-arm64.dmg, audacity-manual-3.7.1.tar.gz, CHECKSUMS.txt, audacity-linux-3.7.1-x64-20.04.AppImage, audacity-linux-3.7.1-x64-22.04.AppImage
GitHubReleasesInfoProvider: Selected asset 'audacity-macOS-3.7.1-x86_64.dmg' from release 'Audacity 3.7.1'
{'Output': {'asset_created_at': '2024-12-11T20:21:48Z',
            'asset_url': 'https://api.github.com/repos/audacity/audacity/releases/assets/212715578',
            'release_notes': 'This is a patch release. It fixes the following '
                             'bugs:\r\n'
                             '\r\n'
                             '* #7797 Effects can be applied to time-stretched '
                             'clips.\r\n'
                             '* #7620 Moving or renaming the installation '
                             'directory no longer re-enables disabled '
                             'modules.\r\n'
                             '* #7652 Opening the "Adjust Playback Speed" '
                             "dialog doesn't crash Audacity anymore.",
            'url': 'https://github.com/audacity/audacity/releases/download/Audacity-3.7.1/audacity-macOS-3.7.1-x86_64.dmg',
            'version': 'Audacity-3.7.1'}}
URLDownloader
{'Input': {'filename': 'Audacity.dmg',
           'url': 'https://github.com/audacity/audacity/releases/download/Audacity-3.7.1/audacity-macOS-3.7.1-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg/Audacity.app',
           'requirement': 'identifier "org.audacityteam.audacity" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'AWEYX923UX'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.8OFOud/Audacity.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.8OFOud/Audacity.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.8OFOud/Audacity.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg/Audacity.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg
Versioner: Found version 3.7.1.0 in file ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg/Audacity.app/Contents/Info.plist
{'Output': {'version': '3.7.1.0'}}
AppPkgCreator
{'Input': {'version': '3.7.1.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/downloads/Audacity.dmg
AppPkgCreator: Using path '/private/tmp/dmg.f5ZSRJ/Audacity.app' matched from globbed '/private/tmp/dmg.f5ZSRJ/*.app'.
AppPkgCreator: BundleID: org.audacityteam.audacity
AppPkgCreator: Copied /private/tmp/dmg.f5ZSRJ/Audacity.app to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/payload/Applications/Audacity.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.audacityteam.audacity',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/Audacity-3.7.1.0.pkg',
                                                        'version': '3.7.1.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.7.1.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/receipts/Audacity.pkg-receipt-20241230-191920.plist

The following packages were built:
    Identifier                 Version  Pkg Path
    ----------                 -------  --------
    org.audacityteam.audacity  3.7.1.0  ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.Audacity/Audacity-3.7.1.0.pkg
```
