### PR TITLE
Deprecate Zeplin recipes

### DIFF
--- a/Zeplin/Zeplin.download.recipe
+++ b/Zeplin/Zeplin.download.recipe
@@ -10,9 +10,18 @@
 		<string>Zeplin</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Zeplin recipes in the hobbithardcase-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
In order to simplify AutoPkg recipe search results, this PR deprecates the Zeplin recipes, which are redundant with the ones in the hobbithardcase-recipes repo.
