### PR TITLE
Change parent of Logitech Options pkg recipe, deprecate download recipe

### DIFF
--- a/Logitech Options/Logitech Options.download.recipe
+++ b/Logitech Options/Logitech Options.download.recipe
@@ -12,9 +12,18 @@
 		<string>Logitech Options</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the LogitechOptions recipes in the joshua-d-miller-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Logitech Options/Logitech Options.pkg.recipe
+++ b/Logitech Options/Logitech Options.pkg.recipe
@@ -14,14 +14,14 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.ahousseini-recipes.download.LogitechOptions</string>
+	<string>com.github.joshua-d-miller.download.logitechoptions</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/LogiMgr Installer*.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/LogiMgr/LogiMgr Installer*.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>
@@ -41,7 +41,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/LogiMgr Installer*.app/Contents/Resources/LogiMgr.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/LogiMgr/LogiMgr Installer*.app/Contents/Resources/LogiMgr.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>


### PR DESCRIPTION
This PR changes the parent recipe of the Logitech Options pkg recipe to the download from joshua-d-miller-recipes, and deprecates the download recipe in this repo.

Verbose recipe run output:

```
% autopkg run -vvq Logitech\ Options.pkg.recipe
Processing Logitech Options.pkg.recipe...
WARNING: Logitech Options.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Logitech Options.zip',
           'url': 'https://download01.logi.com/web/ftp/pub/techsupport/options/options_installer.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/downloads/Logitech Options.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/downloads/Logitech '
                        'Options.zip'}}
Unarchiver
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Logitech Options.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/downloads/Logitech Options.zip to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                      'Installer*'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app' from globbed '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer*'
FileFinder: Basename match: 'LogiMgr Installer 10.22.52.app'
{'Output': {'found_basename': 'LogiMgr Installer 10.22.52.app',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                              'Installer 10.22.52.app'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                         'Installer 10.22.52.app',
           'requirement': 'identifier "com.logitech.manager.installer" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'QED4VVPZWA'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
FileFinder
{'Input': {'find_method': 'glob',
           'pattern': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                      'Installer*.app/Contents/Info.plist'}}
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app/Contents/Info.plist' from globbed '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer*.app/Contents/Info.plist'
FileFinder: Basename match: 'Info.plist'
{'Output': {'found_basename': 'Info.plist',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                              'Installer 10.22.52.app/Contents/Info.plist'}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                               'Installer 10.22.52.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 10.22.52 in file ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app/Contents/Info.plist
{'Output': {'version': '10.22.52'}}
FileFinder
{'Input': {'find_method': 'glob',
           'pattern': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                      'Installer*.app/Contents/Resources/LogiMgr.pkg'}}
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app/Contents/Resources/LogiMgr.pkg' from globbed '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer*.app/Contents/Resources/LogiMgr.pkg'
FileFinder: Basename match: 'LogiMgr.pkg'
{'Output': {'found_basename': 'LogiMgr.pkg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                              'Installer '
                              '10.22.52.app/Contents/Resources/LogiMgr.pkg'}}
PkgCopier
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/Logitech '
                       'Options-10.22.52.pkg',
           'source_pkg': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr '
                         'Installer '
                         '10.22.52.app/Contents/Resources/LogiMgr.pkg'}}
PkgCopier: Copied ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/LogiMgr/LogiMgr Installer 10.22.52.app/Contents/Resources/LogiMgr.pkg to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/Logitech Options-10.22.52.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/Logitech '
                                                               'Options-10.22.52.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/Logitech '
                        'Options-10.22.52.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/receipts/Logitech Options.pkg-receipt-20250101-135640.plist

The following packages were copied:
    Pkg Path
    --------
    ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.pkg.LogitechOptions/Logitech Options-10.22.52.pkg
```
