### PR TITLE
Remove unneeded shebangs from AutoPkg processors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.17.0
+    rev: v1.18.0
     hooks:
       - id: check-autopkg-recipe-list
       - id: check-autopkg-recipes

--- a/Aircall/AircallURLProvider.py
+++ b/Aircall/AircallURLProvider.py
@@ -1,5 +1,3 @@
-#!/usr/local/autopkg/python
-#
 # Copyright 2020 Anver Housseini
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Archi/ArchiLatestGitHubTagProvider.py
+++ b/Archi/ArchiLatestGitHubTagProvider.py
@@ -1,5 +1,3 @@
-#!/usr/local/autopkg/python
-#
 # Copyright 2020 Anver Housseini
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Callbar/CallbarVersionProvider.py
+++ b/Callbar/CallbarVersionProvider.py
@@ -1,5 +1,3 @@
-#!/usr/local/autopkg/python
-#
 # Copyright 2020 Anver Housseini
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/InstaShare/InstaShareURLProvider.py
+++ b/InstaShare/InstaShareURLProvider.py
@@ -1,5 +1,3 @@
-#!/usr/local/autopkg/python
-#
 # Copyright 2023 Anver Housseini
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Lens/LensVersionProvider.py
+++ b/Lens/LensVersionProvider.py
@@ -1,5 +1,3 @@
-#!/usr/local/autopkg/python
-#
 # Copyright 2021 Anver Housseini
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/SharedProcessors/HomebrewCaskURL.py
+++ b/SharedProcessors/HomebrewCaskURL.py
@@ -1,5 +1,3 @@
-#!/usr/local/autopkg/python
-#
 # Copyright 2023 Anver Housseini
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/SilhouetteStudio/SilhouetteStudioURLProvider.py
+++ b/SilhouetteStudio/SilhouetteStudioURLProvider.py
@@ -1,5 +1,3 @@
-#!/usr/local/autopkg/python
-#
 # Copyright 2021 Anver Housseini
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR removes shebangs from Python processors, as processors are loaded as modules instead of executed directly. This should eliminate future cleanup if the AutoPkg Python path ever changes.
