### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/ArtSaverApp/ArtSaverApp.download.recipe
+++ b/ArtSaverApp/ArtSaverApp.download.recipe
@@ -23,7 +23,7 @@
 				<key>re_pattern</key>
 				<string>apps/ArtSaverApp\.app v[0-9\.]* for macOS-%MAJOR_VERSION%\.zip</string>
 				<key>url</key>
-				<string>http://www.cs.uni-bremen.de/~zach/software/ArtSaver/index.html</string>
+				<string>https://www.cs.uni-bremen.de/~zach/software/ArtSaver/index.html</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -47,7 +47,7 @@
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>http://www.cs.uni-bremen.de/~zach/software/ArtSaver/%output_string%</string>
+				<string>https://www.cs.uni-bremen.de/~zach/software/ArtSaver/%output_string%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/CamTwist/CamTwist.download.recipe
+++ b/CamTwist/CamTwist.download.recipe
@@ -23,7 +23,7 @@
 				<key>re_pattern</key>
 				<string>href=.*?CamTwist[._-]?(\d+(?:\.\d+)+)\.dmg</string>
 				<key>url</key>
-				<string>http://camtwiststudio.com/download/</string>
+				<string>https://camtwiststudio.com/download/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -34,7 +34,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>http://camtwiststudio.com/beta/CamTwist_%match%.dmg</string>
+				<string>https://camtwiststudio.com/beta/CamTwist_%match%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/MagicPrefs/MagicPrefs.download.recipe
+++ b/MagicPrefs/MagicPrefs.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>
-				<string>http://magicprefs.com/appcast.xml</string>
+				<string>https://magicprefs.com/appcast.xml</string>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>

--- a/ShapeCollage/ShapeCollage.download.recipe
+++ b/ShapeCollage/ShapeCollage.download.recipe
@@ -25,7 +25,7 @@
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>
-				<string>http://www.shapecollage.com/download/mac</string>
+				<string>https://www.shapecollage.com/download/mac</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._