### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/3CX/3CX.pkg.recipe
+++ b/3CX/3CX.pkg.recipe
@@ -85,8 +85,6 @@
 					</array>
 					<key>id</key>
 					<string>com.3cx.3CXPhone</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdirs</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/</string>
 					<key>pkgname</key>

--- a/Josh Jacob/TNEFsEnough.pkg.recipe
+++ b/Josh Jacob/TNEFsEnough.pkg.recipe
@@ -71,8 +71,6 @@
 					</array>
 					<key>id</key>
 					<string>com.joshjacob.TNEFsEnough</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/LogiTune/LogiTune.pkg.recipe
+++ b/LogiTune/LogiTune.pkg.recipe
@@ -134,8 +134,6 @@ DIR=$(dirname "$0")
 				<dict>
 					<key>id</key>
 					<string>com.logitech.logitune</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MediathekView/MediathekView.pkg.recipe
+++ b/MediathekView/MediathekView.pkg.recipe
@@ -75,8 +75,6 @@
 					</array>
 					<key>id</key>
 					<string>com.install4j.2884-1958-5872-3865.59</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Mersive Solstice/Mersive Solstice.pkg.recipe
+++ b/Mersive Solstice/Mersive Solstice.pkg.recipe
@@ -90,8 +90,6 @@
 					<string>false</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Natron/Natron.pkg.recipe
+++ b/Natron/Natron.pkg.recipe
@@ -49,8 +49,6 @@
 				<dict>
 					<key>id</key>
 					<string>fr.inria.Natron</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Solibri IFC Optimizer/Solibri IFC Optimizer.pkg.recipe
+++ b/Solibri IFC Optimizer/Solibri IFC Optimizer.pkg.recipe
@@ -99,8 +99,6 @@ install_dir=$(dirname "$0")
 					<array/>
 					<key>id</key>
 					<string>com.install4j.SolibriIFCOptimizer</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Touche/Touche.pkg.recipe
+++ b/Touche/Touche.pkg.recipe
@@ -85,8 +85,6 @@
 					</array>
 					<key>id</key>
 					<string>com.red-sweater.touche</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/mBlock/mBlock.pkg.recipe
+++ b/mBlock/mBlock.pkg.recipe
@@ -83,8 +83,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%%ARCH%-%version%</string>
 					<key>pkgroot</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._