### PR TITLE
Deprecate Sonos recipes

### DIFF
--- a/Sonos/Sonos.download.recipe
+++ b/Sonos/Sonos.download.recipe
@@ -14,9 +14,18 @@
 		<string>Sonos</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to Sonos recipes in the arubdesu-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Per the AutoPkg [repo maintenance expectations](https://github.com/autopkg/autopkg/wiki/Sharing-Recipes#repo-maintenance-expectations), duplicate recipes can appear in search results and cause confusion, especially for people getting started with AutoPkg. Consolidating in favor of recipes with the broadest utility helps reduce that noise.

The [Sonos download recipe in arubdesu-recipes](https://github.com/autopkg/arubdesu-recipes/blob/master/Sonos/Sonos.download.recipe) is a more broadly useful alternative to this repo's recipe:
- **Established recipe** — arubdesu-recipes has maintained this recipe since 2015, with more dependent recipes across the org

This consolidation will help simplify search results and lower maintenance effort. Thank you for considering!
