### PR TITLE
Deprecate jamovi recipes

### DIFF
--- a/jamovi/jamovi.download.recipe
+++ b/jamovi/jamovi.download.recipe
@@ -12,9 +12,18 @@
 		<string>jamovi</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to jamovi recipes in the novaksam-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Per the AutoPkg [repo maintenance expectations](https://github.com/autopkg/autopkg/wiki/Sharing-Recipes#repo-maintenance-expectations), duplicate recipes can appear in search results and cause confusion, especially for people getting started with AutoPkg. Consolidating in favor of recipes with the broadest utility helps reduce that noise.

The [jamovi download recipe in novaksam-recipes](https://github.com/autopkg/novaksam-recipes/blob/master/Jamovi/Jamovi.download.recipe) is a more broadly useful alternative to this repo's recipe:
- **Architecture selection** — supports both arm64 and x64 via an `ARCH` input variable
- **Release channel selection** — supports current and solid release channels via a `RELEASE` input variable

This consolidation will help simplify search results and lower maintenance effort. Thank you for considering!