### PR TITLE
Use SparkleUpdateInfoProvider's urlencode_path_component instead of FindAndReplace double-encoding workaround

### DIFF
--- a/MountainDuck/MountainDuck.download.recipe
+++ b/MountainDuck/MountainDuck.download.recipe
@@ -16,7 +16,7 @@
 		<string>Mountain Duck</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -24,6 +24,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://version.mountainduck.io/%MAJOR_VERSION%/macos/changelog.rss</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -31,21 +33,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION

When a Sparkle feed already contains a percent-encoded URL (e.g. `%20` for a space in the filename), `SparkleUpdateInfoProvider` re-encodes it by default — turning `%20` into `%2520`. The `FindAndReplace` step was a workaround to undo that.

`SparkleUpdateInfoProvider` has supported the `urlencode_path_component` input variable since AutoPkg 1.1. Setting it to `false` tells the processor to leave the URL path as-is, so the double-encoding never occurs and the workaround becomes unnecessary.

This PR removes the `FindAndReplace` workaround from one or more of your download recipes.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.

## Verbose output

This shows the `autopkg run -vv` output for your recipe(s) after the change:

```
WARNING: MountainDuck/MountainDuck.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing MountainDuck/MountainDuck.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://version.mountainduck.io/4/macos/changelog.rss',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 29446
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 5.3.0
SparkleUpdateInfoProvider: Found URL https://dist.mountainduck.io/Mountain%20Duck-5.3.0.29446.zip
{'Output': {'url': 'https://dist.mountainduck.io/Mountain%20Duck-5.3.0.29446.zip',
            'version': '5.3.0'}}
URLDownloader
{'Input': {'url': 'https://dist.mountainduck.io/Mountain%20Duck-5.3.0.29446.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://dist.mountainduck.io/Mountain%20Duck-5.3.0.29446.zip', 'file_name': 'Mountain%20Duck-5.3.0.29446.zip', 'file_size': 210358246, 'http_headers': {'Content-Length': 210358246, 'ETag': '934b07ce4bff0e6772b5d07a6c94f0b1', 'Last-Modified': 'Thu, 18 Jun 2026 16:46:15 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/downloads/Mountain%20Duck-5.3.0.29446.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/downloads/Mountain%20Duck-5.3.0.29446.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/downloads/Mountain%20Duck-5.3.0.29446.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain '
                               'Duck',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Mountain%20Duck-5.3.0.29446.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/downloads/Mountain%20Duck-5.3.0.29446.zip to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain Duck
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain '
                         'Duck/Mountain Duck.app',
           'requirement': 'identifier "io.mountainduck" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'G69SCX94XU'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain Duck/Mountain Duck.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain Duck/Mountain Duck.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain Duck/Mountain Duck.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain '
                               'Duck/Mountain Duck.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 5.3.0 in file ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/Mountain Duck/Mountain Duck.app/Contents/Info.plist
{'Output': {'version': '5.3.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ahousseini-recipes.download.MountainDuck/receipts/MountainDuck.download-receipt-20260620-192047.plist

Nothing downloaded, packaged or imported.


```
